### PR TITLE
Consume travellers and perform simulation concurrently

### DIFF
--- a/engine/src/epidemiology_simulation.rs
+++ b/engine/src/epidemiology_simulation.rs
@@ -126,9 +126,9 @@ impl Epidemiology {
         };
         let mut engine_travel_plan = EngineTravelPlan::new(engine_id, population);
         let ticks_consumer = ticks_consumer::start(engine_id);
-        let mut ticks_stream = ticks_consumer.start_with(Duration::from_millis(10), false);
+        let mut ticks_stream = ticks_consumer.start_with(Duration::from_millis(1), false);
         let travellers_consumer = travellers_consumer::start(engine_id);
-        let mut travel_stream = travellers_consumer.start_with(Duration::from_millis(10), false);
+        let mut travel_stream = travellers_consumer.start_with(Duration::from_millis(1), false);
         let mut outgoing: Vec<(Point, Traveller)> = Vec::new();
         let mut n_incoming = 0;
         let mut n_outgoing = 0;

--- a/orchestrator/src/kafka_consumer.rs
+++ b/orchestrator/src/kafka_consumer.rs
@@ -25,6 +25,6 @@ impl KafkaConsumer {
     }
 
     pub fn start_message_stream(&self) -> MessageStream<DefaultConsumerContext> {
-        self.consumer.start_with(Duration::from_millis(10), false)
+        self.consumer.start_with(Duration::from_millis(1), false)
     }
 }


### PR DESCRIPTION
This change allows travellers to be consumed while the simulation loop is run for a tick.
Some changes were needed to make the EngineTravelPlan have immutable borrows. Also reduced the polling interval for consumers to 1ms.