### PR TITLE
Pull out counts calculation into a separate function

### DIFF
--- a/engine/src/disease_state_machine.rs
+++ b/engine/src/disease_state_machine.rs
@@ -72,12 +72,12 @@ impl DiseaseStateMachine {
         }
     }
 
-    pub fn infect(&mut self, rng: &mut RandomWrapper, current_hour: i32, disease: &Disease) -> bool {
+    pub fn infect(&mut self, rng: &mut RandomWrapper, sim_hr: i32, disease: &Disease) -> bool {
         match self.state {
             State::Exposed { at_hour } => {
-                if current_hour - at_hour >= disease.get_exposed_duration() {
+                if sim_hr - at_hour >= disease.get_exposed_duration() {
                     let symptoms = rng.get().gen_bool(1.0 - disease.get_percentage_asymptomatic_population());
-                    let mut severity = InfectionSeverity::Pre { at_hour: current_hour };
+                    let mut severity = InfectionSeverity::Pre { at_hour: sim_hr };
                     if !symptoms {
                         severity = InfectionSeverity::Mild {};
                     }

--- a/engine/src/listeners/events/counts.rs
+++ b/engine/src/listeners/events/counts.rs
@@ -94,6 +94,24 @@ impl Counts {
         self.hour += 1;
     }
 
+    pub fn clear(&mut self) {
+        self.susceptible = 0;
+        self.exposed = 0;
+        self.infected = 0;
+        self.hospitalized = 0;
+        self.recovered = 0;
+        self.deceased = 0;
+    }
+
+    pub fn total(&self) -> i32 {
+        self.susceptible +
+        self.exposed +
+        self.infected +
+        self.hospitalized +
+        self.recovered +
+        self.deceased
+    }
+
     pub fn log(&self) {
         info!("S: {}, E:{}, I: {}, H: {}, R: {}, D: {}", self.get_susceptible(), self.get_exposed(),
               self.get_infected(), self.get_hospitalized(), self.get_recovered(),


### PR DESCRIPTION
Instead of passing around a mutable counts object, calculate the counts after the agent operation is complete. This simplifies the code.